### PR TITLE
Update: Bitwarden setup and multi attachment fetch.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 GO_VERSION ?= 1.23.3
 BW_SECRETS_PATH ?= ""
 BW_PWD_PATH ?= ""
+BW_SECRETS_FOLDER ?= ""
 
 .PHONY: all
 all: install_libs download_secrets set_zsh_default
@@ -22,8 +23,12 @@ ifeq ($(BW_SECRETS_PATH), "")
 	@echo "Error: BW_SECRETS_PATH is not set. Please provide the path to the Bitwarden secrets file." >&2
 	@exit 1
 endif
+ifeq ($(BW_SECRETS_FOLDER), "")
+	@echo "Error: BW_SECRETS_FOLDER is not set. Provide the folder used in Bitwarden." >&2
+	@exit 1
+endif
 	@echo "Downloading secrets using Bitwarden..."
-	bash scripts/download_secrets.sh $(BW_SECRETS_PATH) $(BW_PWD_PATH)
+	bash scripts/download_secrets.sh $(BW_SECRETS_PATH) $(BW_PWD_PATH) $(BW_SECRETS_FOLDER)
 
 # Help target to display usage
 .PHONY: help

--- a/README.md
+++ b/README.md
@@ -2,17 +2,36 @@
 
 This repo is a way to recreate my home machine's environment anywhere.
 
-## Pre Requisite
+## Pre Requisites
 
+1. You need the following dependencies to get started.
+    ```
+    apt install -y git build-essential gnupg
+    ```
+2. This repo requires attachments on Bitwarden which is a premium (~$10/year) feature.
+3. Create a folder/directory and attach your secrets. At least ssh and gpg keys.
+4. Create API keys for bitwarden and save them as json on your disk. Encrypt this using gpg. These can always be rotated and created again.
+5. Create a file that contains your master password. Encrypt this using gpg.
+
+If you are on a clean install, you can download your private key from Bitwarden and run:
 ```
-apt install -y git build-essential
+gpg --import /path/to/private/key
 ```
+This should be the same key used for encrypting Bitwarden API keys and master password.
 
 ## Usage
 
+`BW_SECRETS_PATH`: Local path to encrypted Bitwarden API keys (as json) are stored.
+`BW_SECRETS_FOLDER`: Bitwarden folder (remote) where secrets are stored.
+`BW_PWD_PATH`: Local path to encrypted Bitwarden master password.
+
 ```
-make BW_SECRETS_PATH=/path/to/api_key.json.gpg BW_PWD_PATH=/path/to/password.gpg
-make BW_SECRETS_PATH=/path/to/api_key.json.gpg BW_PWD_PATH=/path/to/password.gpg GO_VERSION=1.23.3
+make BW_SECRETS_PATH=/path/to/api_key.json.gpg BW_PWD_PATH=/path/to/password.gpg BW_SECRETS_FOLDER=ssh
+```
+
+You can choose to install a specific version of golang by providing `GO_VERSION`.
+```
+make BW_SECRETS_PATH=/path/to/api_key.json.gpg BW_PWD_PATH=/path/to/password.gpg BW_SECRETS_FOLDER=ssh GO_VERSION=1.23.3
 ```
 
 ## Breakdown

--- a/scripts/download_secrets.sh
+++ b/scripts/download_secrets.sh
@@ -2,6 +2,7 @@
 
 BW_SECRETS_PATH=$1
 BW_PWD=$2
+BW_SECRETS_FOLDER=$3
 BW_DOWNLOAD_URL="https://vault.bitwarden.com/download/?app=cli&platform=linux"
 INSTALL_DIR="$HOME/packages"  # Adjust the installation directory if needed
 ZIP_FILE="/tmp/bw-cli.zip"
@@ -59,7 +60,7 @@ function bw_login() {
 }
 
 function bw_get_secrets() {
-  folder_id=$(bw list folders | jq -r '.[] | select (.name == "ssh") | .id')
+  folder_id=$(bw list folders | jq -r '.[] | select (.name == "$BW_SECRETS_FOLDER") | .id')
   items=$(bw list items --folderid "$folder_id")
 
   if [ ! -d "$HOME/.ssh" ]; then

--- a/scripts/download_secrets.sh
+++ b/scripts/download_secrets.sh
@@ -58,17 +58,22 @@ function bw_login() {
     rm "$temp_file"
 }
 
-function bw_get_ssh_keys() {
-    folder_id=$(bw list folders | jq -r '.[] | select (.name == "ssh") | .id')
-    items=$(bw list items --folderid "$folder_id")
-    item_id=$(echo "$items" | jq -r '.[].id')
-    attachments=$(echo "$items" | jq '[.[].attachments[] | {attachment_id: .id, file_name: .fileName}]')
+function bw_get_secrets() {
+  folder_id=$(bw list folders | jq -r '.[] | select (.name == "ssh") | .id')
+  items=$(bw list items --folderid "$folder_id")
 
-    for row in $(echo "$attachments" | jq -c '.[]'); do
-        attachment_id=$(echo "$row" | jq -r '.attachment_id')
-        file_name=$(echo "$row" | jq -r '.file_name')
-        bw get attachment "$attachment_id" --itemid "$item_id" --output ~/.ssh/"${file_name}"
-    done
+  if [ ! -d "$HOME/.ssh" ]; then
+    mkdir -p "$HOME/.ssh"
+  fi
+
+  echo "$items" | jq -r --arg home "$HOME" '
+    .[]
+    | .id as $item_id
+    | .attachments[]
+    | "bw get attachment \(.id) --itemid \($item_id) --output \($home)/.ssh/\(.fileName)"
+  ' | while IFS= read -r cmd; do
+    eval "$cmd"
+  done
 }
 
 download_cli
@@ -80,4 +85,4 @@ rm -f "$ZIP_FILE"
 
 check_bw_secrets_path
 bw_login "$BW_SECRETS_PATH"
-bw_get_ssh_keys
+bw_get_secrets

--- a/scripts/install_libs.sh
+++ b/scripts/install_libs.sh
@@ -38,7 +38,7 @@ function install_base_libs_apt() {
     cmake \
     curl \
     liblzma-dev \
-    gcc \ 
+    gcc \
     wget \
     curl \
     pipx \

--- a/scripts/install_libs.sh
+++ b/scripts/install_libs.sh
@@ -28,8 +28,7 @@ function install_base_libs_apt() {
     libsqlite3-dev \
     libffi-dev \
     libnss3-dev \
-    libncurses5-dev \
-    libncursesw5-dev \
+    libncurses-dev \
     libgdbm-dev \
     libgdbm-compat-dev \
     uuid-dev \


### PR DESCRIPTION
## Changes

1. Better documentation for pre-requisites.
2. Doesn't require users to set the folder name as `ssh` on their bitwarden accounts.
3. Download multiple items and attachments from a Bitwarden folder.
4. Fix download apt dependencies:
    1. `gcc \ ` the whitespace breaks the multi-line parser and no dependencies are downloaded thereafter.
    2. `libcurses` had typos.

## Tests

Manually tested using wsl Ubuntu 24.04